### PR TITLE
Include false values

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "apple/news"
+require "apple-news"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/apple-news/properties.rb
+++ b/lib/apple-news/properties.rb
@@ -11,7 +11,7 @@ module AppleNews
       self.class.properties.each do |prop, settings|
         val = if !settings[:klass].nil?
           assigned_val = opts.fetch(prop, settings[:default])
-          
+
           if settings[:default].is_a?(Array)
             assigned_val.map { |v|
               v.is_a?(Hash) ? settings[:klass].send(settings[:init_method], v) : v
@@ -69,7 +69,7 @@ module AppleNews
             send(key)
           end
 
-          [json_key, val.blank? ? nil : val]
+          [json_key, val.blank? && val != false ? nil : val]
         }.reject { |p| p[1].nil? }]
       end
     end

--- a/spec/apple/article_spec.rb
+++ b/spec/apple/article_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe AppleNews::Article do
+  it 'retains false values' do
+    article = AppleNews::Article.new
+    article.is_preview = false
+    expect(article.as_json["isPreview"]).to be(false)
+  end
+end

--- a/spec/apple/news_spec.rb
+++ b/spec/apple/news_spec.rb
@@ -1,11 +1,7 @@
 require 'spec_helper'
 
-describe Apple::News do
+describe AppleNews do
   it 'has a version number' do
-    expect(Apple::News::VERSION).not_to be nil
-  end
-
-  it 'does something useful' do
-    expect(false).to eq(true)
+    expect(AppleNews::VERSION).not_to be nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'apple/news'
+require 'apple-news'


### PR DESCRIPTION
Hey there,

As described in the readme, you should be able to set the `is_preview` as so:

`article.is_preview = false`

The problem is that in `Properties#as_json` we are checking if `val.blank?` and then dropping all non-blank values. 

Since `false.blank? == true` that means that the `is_preview` property won't be included at all.

Probably a way to solve it is to exclude false values from the check.

Until then, a temporary workaround is to define it as a string: `article.is_preview = "false"`.

Please let me know if the suggested solution makes sense.

Cheers,
Giorgos