### PR TITLE
Multiple Configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,19 @@ AppleNews.config.api_key_secret = "miJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 You can fetch the Channel information by calling:
 
 ``` ruby
-channel = AppleNews::Channel.current
+channel = AppleNews.config.channel
 ```
 
-Because each channel has a separate API key, there is only ever one channel that you can fetch.
+If working with multiple channels:
+
+```ruby
+config = AppleNews::Configuration.new(
+  channel_id:     '...',
+  api_key_id:     '...',
+  api_key_secret: '...'
+)
+channel = config.channel
+```
 
 ### Sections
 
@@ -48,7 +57,7 @@ You can either fetch sections by their ID, or by fetching all of them through th
 section = AppleNews::Section.new(section_id)
 
 # or
-channel = AppleNews::Channel.current
+channel = AppleNews.config.channel
 channel.default_section # for the default section
 channel.sections # for all the sections
 ```
@@ -61,7 +70,7 @@ You can fetch articles either by their ID, their channel, or their section.
 article = AppleNews::Article.new(article_id)
 
 # or
-channel = AppleNews::Channel.current
+channel = AppleNews.config.channel
 channel.articles # all articles in the channel
 channel.default_section.articles # all articles in the default section
 ```

--- a/lib/apple-news/article.rb
+++ b/lib/apple-news/article.rb
@@ -10,18 +10,19 @@ module AppleNews
     include Resource
     include Properties
 
-    optional_properties :is_sponsored, :is_preview, :accessory_text, :revision
+    optional_properties :is_sponsored, :is_preview, :accessory_text, :revision, :type
     optional_property :links, {}
 
     attr_reader :id, :share_url, :state
     attr_accessor :document
     def_delegator :@document, :title
 
-    def initialize(id = nil, data = {})
+    def initialize(id = nil, data = {}, config = AppleNews.config)
       super(data)
 
-      @resource_path = "/articles"
       @id = id
+      @config = config
+      @resource_path = "/articles"
 
       document = (data[:document] || data['document'])
       @document = document.is_a?(AppleNews::Document) ? document : Document.new(document)

--- a/lib/apple-news/article.rb
+++ b/lib/apple-news/article.rb
@@ -10,7 +10,7 @@ module AppleNews
     include Resource
     include Properties
 
-    optional_properties :is_sponsored, :is_preview, :accessory_text, :revision, :type
+    optional_properties :is_sponsored, :is_preview, :accessory_text, :revision
     optional_property :links, {}
 
     attr_reader :id, :share_url, :state

--- a/lib/apple-news/article/persistence.rb
+++ b/lib/apple-news/article/persistence.rb
@@ -5,7 +5,7 @@ module AppleNews
 
       included do
         def save!
-          request = Request::Post.new(endpoint_url)
+          request = Request::Post.new(endpoint_url, config)
           request.fields = {
             'metadata' => metadata_field,
             'article.json' => document_json
@@ -27,7 +27,7 @@ module AppleNews
         alias_method :saved?, :persisted?
 
         def delete!
-          request = Request::Delete.new(endpoint_url)
+          request = Request::Delete.new(endpoint_url, config)
           resp = request.call
 
           return resp['errors'] if resp.is_a?(Hash) && resp.has_key?('errors')
@@ -65,7 +65,7 @@ module AppleNews
           if persisted?
             "/articles/#{id}"
           else
-            "/channels/#{AppleNews.config.channel_id}/articles"
+            "/channels/#{config.channel_id}/articles"
           end
         end
 

--- a/lib/apple-news/channel.rb
+++ b/lib/apple-news/channel.rb
@@ -7,7 +7,9 @@ module AppleNews
                 :default_section, :share_url
 
     def self.current
-      self.new(AppleNews.config.channel_id)
+      warn 'DEPRECATION WARNING: `AppleNews::Channel.current` is deprecated. '\
+           'Please use `AppleNews.config.channel` instead.'
+      AppleNews.config.channel
     end
 
     def initialize(id, data = nil, config = AppleNews.config)

--- a/lib/apple-news/channel.rb
+++ b/lib/apple-news/channel.rb
@@ -10,30 +10,31 @@ module AppleNews
       self.new(AppleNews.config.channel_id)
     end
 
-    def initialize(id, data = nil)
+    def initialize(id, data = nil, config = AppleNews.config)
       @id = id
-      @resource_path = "/channels"
+      @config = config
+      @resource_path = '/channels'
 
       data.nil? ? hydrate! : set_read_only_properties(data)
     end
 
     def default_section
-      Section.new(section_link_id('defaultSection'))
+      Section.new(section_link_id('defaultSection'), nil, config)
     end
 
     def sections
-      request = Request::Get.new("/channels/#{id}/sections")
+      request = Request::Get.new("/channels/#{id}/sections", config)
       resp = request.call
       resp['data'].map do |section|
-        Section.new(section['id'], section)
+        Section.new(section['id'], section, config)
       end
     end
 
     def articles(params = {})
-      request = Request::Get.new("/channels/#{id}/articles")
+      request = Request::Get.new("/channels/#{id}/articles", config)
       resp = request.call(params)
       resp['data'].map do |article|
-        Article.new(article['id'])
+        Article.new(article['id'], {}, config)
       end
     end
   end

--- a/lib/apple-news/configuration.rb
+++ b/lib/apple-news/configuration.rb
@@ -8,5 +8,9 @@ module AppleNews
       @api_key_secret = attributes[:api_key_secret]
       @api_base       = attributes[:api_base] || 'https://news-api.apple.com'
     end
+
+    def channel
+      AppleNews::Channel.new(channel_id, nil, self)
+    end
   end
 end

--- a/lib/apple-news/configuration.rb
+++ b/lib/apple-news/configuration.rb
@@ -1,12 +1,12 @@
 module AppleNews
   class Configuration
     attr_accessor :channel_id, :api_key_id, :api_key_secret, :api_base
-    
-    def initialize
-      @channel_id = nil
-      @api_key_id = nil
-      @api_key_secret = nil
-      @api_base = 'https://news-api.apple.com'
+
+    def initialize(attributes = {})
+      @channel_id     = attributes[:channel_id]
+      @api_key_id     = attributes[:api_key_id]
+      @api_key_secret = attributes[:api_key_secret]
+      @api_base       = attributes[:api_base] || 'https://news-api.apple.com'
     end
   end
 end

--- a/lib/apple-news/requests/delete.rb
+++ b/lib/apple-news/requests/delete.rb
@@ -3,8 +3,8 @@ module AppleNews
     class Delete
       attr_reader :url
 
-      def initialize(url)
-        @config = AppleNews.config
+      def initialize(url, config = AppleNews.config)
+        @config = config
         @url = URI::parse(File.join(@config.api_base, url))
       end
 
@@ -20,7 +20,7 @@ module AppleNews
       private
 
       def headers
-        security = AppleNews::Security.new('DELETE', @url.to_s)
+        security = AppleNews::Security.new('DELETE', @url.to_s, @config)
         { 'Authorization' => security.authorization }
       end
     end

--- a/lib/apple-news/requests/get.rb
+++ b/lib/apple-news/requests/get.rb
@@ -3,8 +3,8 @@ module AppleNews
     class Get
       attr_reader :url
 
-      def initialize(url)
-        @config = AppleNews.config
+      def initialize(url, config = AppleNews.config)
+        @config = config
         @url = URI::parse(File.join(@config.api_base, url))
       end
 
@@ -20,7 +20,7 @@ module AppleNews
       private
 
       def headers
-        security = AppleNews::Security.new('GET', @url.to_s)
+        security = AppleNews::Security.new('GET', @url.to_s, @config)
         { 'Authorization' => security.authorization }
       end
     end

--- a/lib/apple-news/requests/post.rb
+++ b/lib/apple-news/requests/post.rb
@@ -4,8 +4,8 @@ module AppleNews
       attr_reader :url
       attr_accessor :fields
 
-      def initialize(url)
-        @config = AppleNews.config
+      def initialize(url, config = AppleNews.config)
+        @config = config
         @url = URI::parse(File.join(@config.api_base, url))
         @fields = {}
       end
@@ -42,7 +42,7 @@ module AppleNews
       end
 
       def authorization
-        security = AppleNews::Security.new('POST', @url)
+        security = AppleNews::Security.new('POST', @url, @config)
         security.content_type = "multipart/form-data; boundary=#{Net::HTTP::Post::Multipart::DEFAULT_BOUNDARY}"
         security.content_body = content_body
 

--- a/lib/apple-news/resource.rb
+++ b/lib/apple-news/resource.rb
@@ -3,6 +3,8 @@ module AppleNews
     extend ActiveSupport::Concern
 
     included do
+      attr_accessor :config
+
       def update_with_data(data)
         load_properties(data)
       end
@@ -22,7 +24,7 @@ module AppleNews
       end
 
       def fetch_data
-        request = AppleNews::Request::Get.new(resource_url)
+        request = AppleNews::Request::Get.new(resource_url, config)
         request.call
       end
 

--- a/lib/apple-news/section.rb
+++ b/lib/apple-news/section.rb
@@ -5,22 +5,23 @@ module AppleNews
 
     attr_reader :id, :type, :name, :is_default, :links, :created_at, :modified_at, :share_url
 
-    def initialize(id, data = nil)
+    def initialize(id, data = nil, config = AppleNews.config)
       @id = id
+      @config = config
       @resource_path = "/sections"
 
       data.nil? ? hydrate! : set_read_only_properties(data)
     end
 
     def channel
-      Channel.new(channel_link_id('channel'))
+      Channel.new(channel_link_id('channel'), nil, config)
     end
 
     def articles(params = {})
-      request = Request::Get.new("/sections/#{id}/articles")
+      request = Request::Get.new("/sections/#{id}/articles", config)
       resp = request.call(params)
       resp['data'].map do |article|
-        Article.new(article['id'])
+        Article.new(article['id'], {}, config)
       end
     end
   end

--- a/lib/apple-news/security.rb
+++ b/lib/apple-news/security.rb
@@ -1,12 +1,14 @@
+require 'base64'
+require 'openssl'
+
 module AppleNews
   class Security
     attr_accessor :method, :url, :content_type, :content_body
 
-    def initialize(method, url)
-      @config = AppleNews.config
-
+    def initialize(method, url, config = AppleNews.config)
       @method = method.upcase
       @url = url
+      @config = config
       @date = Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
       @content_type = nil
       @content_body = nil

--- a/spec/apple/article_spec.rb
+++ b/spec/apple/article_spec.rb
@@ -1,9 +1,64 @@
 require 'spec_helper'
 
 describe AppleNews::Article do
+
+  let(:fixture_data) do
+    {
+      'id'    => '111',
+      'type'  => 'article',
+      'title' => 'Test Article',
+      'state' => 'PROCESSING'
+    }
+  end
+
   it 'retains false values' do
     article = AppleNews::Article.new
     article.is_preview = false
-    expect(article.as_json["isPreview"]).to be(false)
+    expect(article.as_json['isPreview']).to be(false)
   end
+
+  context 'created with only an id' do
+    let(:article) { AppleNews::Article.new('111') }
+
+    before do
+      allow_any_instance_of(AppleNews::Article).to receive(:fetch_data).and_return('data' => fixture_data)
+    end
+
+    it 'will fetch attributes from the api' do
+      expect(article.type).to eq('article')
+      expect(article.state).to eq('PROCESSING')
+    end
+
+    it 'will use the default config' do
+      expect(article.config).to be(AppleNews.config)
+    end
+  end
+
+  context 'created with id and a data hash' do
+    let(:article) { AppleNews::Article.new('111', fixture_data) }
+
+    it 'will set data attributes without fetching' do
+      expect(article.type).to eq('article')
+      expect(article.state).to eq('PROCESSING')
+    end
+
+    it 'will use the default config' do
+      expect(article.config).to be(AppleNews.config)
+    end
+  end
+
+  context 'created with id, data hash, and custom config' do
+    let(:config) { AppleNews::Configuration.new }
+    let(:article) { AppleNews::Article.new('111', fixture_data, config) }
+
+    it 'will set data attributes without fetching' do
+      expect(article.type).to eq('article')
+      expect(article.state).to eq('PROCESSING')
+    end
+
+    it 'will use the custom config' do
+      expect(article.config).to be(config)
+    end
+  end
+
 end

--- a/spec/apple/article_spec.rb
+++ b/spec/apple/article_spec.rb
@@ -25,7 +25,7 @@ describe AppleNews::Article do
     end
 
     it 'will fetch attributes from the api' do
-      expect(article.type).to eq('article')
+      expect(article.id).to eq('111')
       expect(article.state).to eq('PROCESSING')
     end
 
@@ -38,7 +38,7 @@ describe AppleNews::Article do
     let(:article) { AppleNews::Article.new('111', fixture_data) }
 
     it 'will set data attributes without fetching' do
-      expect(article.type).to eq('article')
+      expect(article.id).to eq('111')
       expect(article.state).to eq('PROCESSING')
     end
 
@@ -52,7 +52,7 @@ describe AppleNews::Article do
     let(:article) { AppleNews::Article.new('111', fixture_data, config) }
 
     it 'will set data attributes without fetching' do
-      expect(article.type).to eq('article')
+      expect(article.id).to eq('111')
       expect(article.state).to eq('PROCESSING')
     end
 

--- a/spec/apple/channel_spec.rb
+++ b/spec/apple/channel_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe AppleNews::Channel do
+
+  let(:fixture_data) do
+    {
+      'id'    => '111',
+      'type'  => 'channel',
+      'name'  => 'Test Channel',
+      'links' => {
+        'defaultSection' => 'https://news-api.apple.com/sections/4523e2f6'
+      }
+    }
+  end
+
+  context 'created with only an id' do
+    let(:channel) { AppleNews::Channel.new('111') }
+
+    before do
+      allow_any_instance_of(AppleNews::Channel).to receive(:fetch_data).and_return('data' => fixture_data)
+    end
+
+    it 'will fetch attributes from the api' do
+      expect(channel.type).to eq('channel')
+      expect(channel.name).to eq('Test Channel')
+    end
+
+    it 'will use the default config' do
+      expect(channel.config).to be(AppleNews.config)
+    end
+  end
+
+  context 'created with id and a data hash' do
+    let(:channel) { AppleNews::Channel.new('111', fixture_data) }
+
+    it 'will set data attributes without fetching' do
+      expect(channel.type).to eq('channel')
+      expect(channel.name).to eq('Test Channel')
+    end
+
+    it 'will use the default config' do
+      expect(channel.config).to be(AppleNews.config)
+    end
+  end
+
+  context 'created with id, data hash, and custom config' do
+    let(:config) { AppleNews::Configuration.new }
+    let(:channel) { AppleNews::Channel.new('111', fixture_data, config) }
+
+    it 'will set data attributes without fetching' do
+      expect(channel.type).to eq('channel')
+      expect(channel.name).to eq('Test Channel')
+    end
+
+    it 'will use the custom config' do
+      expect(channel.config).to be(config)
+    end
+
+    it 'will use the custom config when loading sections' do
+      allow_any_instance_of(AppleNews::Section).to receive(:fetch_data).and_return('data' => {})
+      section = channel.default_section
+      expect(section.config).to be(config)
+    end
+  end
+
+end

--- a/spec/apple/configuration_spec.rb
+++ b/spec/apple/configuration_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe AppleNews::Configuration do
+
+  let(:attributes) do
+    {
+      channel_id:     '12345',
+      api_key_id:     'testkey',
+      api_key_secret: 'dGVzdHNlY3JldA=='
+    }
+  end
+
+  it 'can be created via an attributes hash' do
+    config = AppleNews::Configuration.new(attributes)
+    expect(config.channel_id).to eq('12345')
+  end
+
+  it 'has a default value for api_base' do
+    config = AppleNews::Configuration.new(attributes)
+    expect(config.api_base).to eq('https://news-api.apple.com')
+  end
+
+  it 'returns the configured channel' do
+    allow_any_instance_of(AppleNews::Channel).to receive(:fetch_data).and_return('data' => {})
+    config = AppleNews::Configuration.new(attributes)
+    expect(config.channel.id).to eq('12345')
+  end
+
+end

--- a/spec/apple/requests/delete_spec.rb
+++ b/spec/apple/requests/delete_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe AppleNews::Request::Delete do
+
+  it 'builds the url from the config' do
+    config  = AppleNews::Configuration.new(api_base: 'https://api.foo.com')
+    request = AppleNews::Request::Delete.new('/somepath', config)
+    expect(request.url.to_s).to eq('https://api.foo.com/somepath')
+  end
+
+end

--- a/spec/apple/requests/get_spec.rb
+++ b/spec/apple/requests/get_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe AppleNews::Request::Get do
+
+  it 'builds the url from the config' do
+    config  = AppleNews::Configuration.new(api_base: 'https://api.foo.com')
+    request = AppleNews::Request::Get.new('/somepath', config)
+    expect(request.url.to_s).to eq('https://api.foo.com/somepath')
+  end
+
+end

--- a/spec/apple/requests/post_spec.rb
+++ b/spec/apple/requests/post_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe AppleNews::Request::Post do
+
+  it 'builds the url from the config' do
+    config  = AppleNews::Configuration.new(api_base: 'https://api.foo.com')
+    request = AppleNews::Request::Post.new('/somepath', config)
+    expect(request.url.to_s).to eq('https://api.foo.com/somepath')
+  end
+
+end

--- a/spec/apple/section_spec.rb
+++ b/spec/apple/section_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe AppleNews::Section do
+
+  let(:fixture_data) do
+    {
+      'id'    => '111',
+      'type'  => 'section',
+      'name'  => 'Test Section',
+      'links' => {
+        'channel' => 'https://news-api.apple.com/channels/a5164537'
+      }
+    }
+  end
+
+  context 'created with only an id' do
+    let(:section) { AppleNews::Section.new('111') }
+
+    before do
+      allow_any_instance_of(AppleNews::Section).to receive(:fetch_data).and_return('data' => fixture_data)
+    end
+
+    it 'will fetch attributes from the api' do
+      expect(section.type).to eq('section')
+      expect(section.name).to eq('Test Section')
+    end
+
+    it 'will use the default config' do
+      expect(section.config).to be(AppleNews.config)
+    end
+  end
+
+  context 'created with id and a data hash' do
+    let(:section) { AppleNews::Section.new('111', fixture_data) }
+
+    it 'will set data attributes without fetching' do
+      expect(section.type).to eq('section')
+      expect(section.name).to eq('Test Section')
+    end
+
+    it 'will use the default config' do
+      expect(section.config).to be(AppleNews.config)
+    end
+  end
+
+  context 'created with id, data hash, and custom config' do
+    let(:config) { AppleNews::Configuration.new }
+    let(:section) { AppleNews::Section.new('111', fixture_data, config) }
+
+    it 'will set data attributes without fetching' do
+      expect(section.type).to eq('section')
+      expect(section.name).to eq('Test Section')
+    end
+
+    it 'will use the custom config' do
+      expect(section.config).to be(config)
+    end
+
+    it 'will use the custom config when loading channel' do
+      allow_any_instance_of(AppleNews::Channel).to receive(:fetch_data).and_return('data' => {})
+      channel = section.channel
+      expect(channel.config).to be(config)
+    end
+  end
+
+end

--- a/spec/apple/security_spec.rb
+++ b/spec/apple/security_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe AppleNews::Security do
+
+  it 'creates an HMAC auth header' do
+    config = AppleNews::Configuration.new(
+      api_key_id:     'testkey',
+      api_key_secret: 'dGVzdHNlY3JldA=='
+    )
+    security = AppleNews::Security.new('GET', 'http://foo.com/', config)
+    expect(security.authorization).to match(/^HHMAC; key=#{config.api_key_id}; signature=(.+); date=(.+)$/)
+  end
+
+end


### PR DESCRIPTION
### Purpose

This pull request adds support for managing multiple Apple News channels in the same application. It does so by adding an optional `config` argument to the various `Resource` constructors. The argument defaults to `AppleNews.config`, so this should be a backwards compatible change for all current consumers of the gem.

### Notable Changes

- Added optional `config` argument to various constructors.

- I also added `Configuration#channel` so that the API was nice and clean. The alternative was `AppleNews::Channel.new(config.channel_id, nil, config)`, which IMHO seemed a little verbose. Since `#channel` seemed to duplicate `Channel.current`, I depreciated it so there weren't two methods doing the same thing. If you'd rather the depreciation be reverted, I'm happy to do so.

- Added a bunch of specs: partly to validate my changes, partly to help me understand the code, and partly to ensure that nothing was exploding :grin: - _Safety First™_.

### Tests

All specs appear to pass using:

```bash
./bin/setup
bundle exec rake
```
