### PR TITLE
Opt out of article hydration

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ channel.articles # all articles in the channel
 channel.default_section.articles # all articles in the default section
 ```
 
+The 10 most recent articles are returned by default. To change the number or sort order, you can pass any of [the query params defined in the API docs](https://developer.apple.com/library/content/documentation/General/Conceptual/News_API_Ref/SearchArticles.html#//apple_ref/doc/uid/TP40015409-CH17-SW1). For example:
+
+``` ruby
+# first 5 articles
+channel.articles(sortDir: 'ASC', pageSize: 5)
+```
+
+A "Read Article" API request will be made for each article to ensure that `#document` exists (the search endpoint only returns read-only attributes). If you don't need to access the document, you can opt-out of this behavior via:
+
+``` ruby
+channel.articles(hydrate: false)
+```
+
 ## Submitting Articles
 
 Apple News articles are submitted as "bundles", with the article content and attached files together in one request. Because of this, we have the concept of a Document. The Document is what contains the actual article content in the Apple News JSON format. The Article encapsulates this and also includes all of the files that will be submitted along with the document.

--- a/lib/apple-news/channel.rb
+++ b/lib/apple-news/channel.rb
@@ -25,18 +25,19 @@ module AppleNews
     end
 
     def sections
-      request = Request::Get.new("/channels/#{id}/sections", config)
-      resp = request.call
+      resp = get_request("/channels/#{id}/sections")
       resp['data'].map do |section|
         Section.new(section['id'], section, config)
       end
     end
 
     def articles(params = {})
-      request = Request::Get.new("/channels/#{id}/articles", config)
-      resp = request.call(params)
+      params  = params.with_indifferent_access
+      hydrate = params.delete(:hydrate)
+      resp = get_request("/channels/#{id}/articles", params)
       resp['data'].map do |article|
-        Article.new(article['id'], {}, config)
+        data = hydrate == false ? article : {}
+        Article.new(article['id'], data, config)
       end
     end
   end

--- a/lib/apple-news/properties.rb
+++ b/lib/apple-news/properties.rb
@@ -9,8 +9,9 @@ module AppleNews
     def load_properties(opts)
       opts = ActiveSupport::HashWithIndifferentAccess.new(opts || {})
       self.class.properties.each do |prop, settings|
+        camelized_prop = prop.to_s.camelize(:lower)
         val = if !settings[:klass].nil?
-          assigned_val = opts.fetch(prop, settings[:default])
+          assigned_val = opts.fetch(camelized_prop, settings[:default])
 
           if settings[:default].is_a?(Array)
             assigned_val.map { |v|
@@ -26,7 +27,7 @@ module AppleNews
             assigned_val.nil? ? nil : settings[:klass].send(settings[:init_method], assigned_val)
           end
         else
-          opts.fetch(prop, settings[:default])
+          opts.fetch(camelized_prop, settings[:default])
         end
 
         instance_variable_set "@#{prop}", val

--- a/lib/apple-news/resource.rb
+++ b/lib/apple-news/resource.rb
@@ -13,6 +13,10 @@ module AppleNews
         File.join(@resource_path, id)
       end
 
+      def get_request(path, params = {})
+        AppleNews::Request::Get.new(path, config).call(params)
+      end
+
       private
 
       def hydrate!
@@ -24,8 +28,7 @@ module AppleNews
       end
 
       def fetch_data
-        request = AppleNews::Request::Get.new(resource_url, config)
-        request.call
+        get_request(resource_url)
       end
 
       def set_read_only_properties(data)

--- a/lib/apple-news/resource.rb
+++ b/lib/apple-news/resource.rb
@@ -33,7 +33,7 @@ module AppleNews
 
       def set_read_only_properties(data)
         data.each do |k, v|
-          instance_variable_set("@#{k.underscore}", v)
+          instance_variable_set("@#{k.to_s.underscore}", v)
         end
       end
     end

--- a/lib/apple-news/section.rb
+++ b/lib/apple-news/section.rb
@@ -8,7 +8,7 @@ module AppleNews
     def initialize(id, data = nil, config = AppleNews.config)
       @id = id
       @config = config
-      @resource_path = "/sections"
+      @resource_path = '/sections'
 
       data.nil? ? hydrate! : set_read_only_properties(data)
     end
@@ -18,10 +18,12 @@ module AppleNews
     end
 
     def articles(params = {})
-      request = Request::Get.new("/sections/#{id}/articles", config)
-      resp = request.call(params)
+      params  = params.with_indifferent_access
+      hydrate = params.delete(:hydrate)
+      resp = get_request("/sections/#{id}/articles", params)
       resp['data'].map do |article|
-        Article.new(article['id'], {}, config)
+        data = hydrate == false ? article : {}
+        Article.new(article['id'], data, config)
       end
     end
   end

--- a/spec/apple/article_spec.rb
+++ b/spec/apple/article_spec.rb
@@ -4,10 +4,27 @@ describe AppleNews::Article do
 
   let(:fixture_data) do
     {
-      'id'    => '111',
-      'type'  => 'article',
-      'title' => 'Test Article',
-      'state' => 'PROCESSING'
+      'id'                      => '111',
+      'type'                    => 'article',
+      'title'                   => 'Test Article',
+      'state'                   => 'PROCESSING',
+      'createdAt'               => '2015-02-28T00:49:36Z',
+      'modifiedAt'              => '2015-02-28T00:49:36Z',
+      'shareUrl'                => 'https://apple.news/111',
+      'revision'                => 'AAAAAAAAAAAAAAAAAAAAew==',
+      'accessoryText'           => 'by Some Author',
+      'maturityRating'          => 'GENERAL',
+      'warnings'                => [],
+      'isCandidateToBeFeatured' => true,
+      'isSponsored'             => false,
+      'isPreview'               => false,
+      'links' => {
+        'channel' => 'https://news-api.apple.com/channels/c111',
+        'sections' => [
+          'https://news-api.apple.com/sections/s111',
+          'https://news-api.apple.com/sections/s222'
+        ]
+      }
     }
   end
 
@@ -15,6 +32,24 @@ describe AppleNews::Article do
     article = AppleNews::Article.new
     article.is_preview = false
     expect(article.as_json['isPreview']).to be(false)
+  end
+
+  it 'supports passing in a document' do
+    document = AppleNews::Document.new(title: 'My Article')
+    article = AppleNews::Article.new('111', document: document)
+    expect(article.document).to be(document)
+    expect(article.document.title).to eq('My Article')
+  end
+
+  it 'will create a document if one is in the data hash' do
+    article = AppleNews::Article.new('111', 'document' => { title: 'My Article' })
+    expect(article.document).to be_a(AppleNews::Document)
+    expect(article.document.title).to eq('My Article')
+  end
+
+  it 'will ensure a document if one is not in the data hash' do
+    article = AppleNews::Article.new('111', type: 'article')
+    expect(article.document).to be_a(AppleNews::Document)
   end
 
   context 'created with only an id' do
@@ -53,7 +88,46 @@ describe AppleNews::Article do
 
     it 'will set data attributes without fetching' do
       expect(article.id).to eq('111')
+      expect(article.type).to eq('article')
+      expect(article.title).to eq('Test Article')
       expect(article.state).to eq('PROCESSING')
+      expect(article.created_at).to eq('2015-02-28T00:49:36Z')
+      expect(article.modified_at).to eq('2015-02-28T00:49:36Z')
+      expect(article.share_url).to eq('https://apple.news/111')
+      expect(article.revision).to eq('AAAAAAAAAAAAAAAAAAAAew==')
+      expect(article.accessory_text).to eq('by Some Author')
+      expect(article.maturity_rating).to eq('GENERAL')
+      expect(article.warnings).to eq([])
+      expect(article.is_candidate_to_be_featured).to eq(true)
+      expect(article.is_sponsored).to eq(false)
+      expect(article.is_preview).to eq(false)
+    end
+
+    it 'will serialize the correct attributes as metadata JSON' do
+      # make some updates so we know that properties are being persisted/marshalled correctly
+      article.revision = 'BBBBBB=='
+      article.accessory_text = 'by New Author'
+      article.maturity_rating = 'KIDS'
+      article.is_candidate_to_be_featured = false
+      article.is_sponsored = true
+      article.links = {
+        'sections' => [
+          'https://news-api.apple.com/sections/s333'
+        ]
+      }
+      expect(article.as_json).to eq(
+        'revision'                => 'BBBBBB==',
+        'accessoryText'           => 'by New Author',
+        'maturityRating'          => 'KIDS',
+        'isCandidateToBeFeatured' => false,
+        'isSponsored'             => true,
+        'isPreview'               => false,
+        'links' => {
+          'sections' => [
+            'https://news-api.apple.com/sections/s333'
+          ]
+        }
+      )
     end
 
     it 'will use the custom config' do

--- a/spec/apple/channel_spec.rb
+++ b/spec/apple/channel_spec.rb
@@ -61,6 +61,23 @@ describe AppleNews::Channel do
       section = channel.default_section
       expect(section.config).to be(config)
     end
+
+    it 'will load and hydrate articles' do
+      allow_any_instance_of(AppleNews::Article).to receive(:fetch_data).and_return('data' => {})
+      expect(channel).to receive(:get_request).and_return(
+        'data' => [{ 'id' => '123', 'type' => 'article', 'title' => 'Test Article' }]
+      )
+      article = channel.articles.first
+      expect(article.id).to eq('123')
+    end
+
+    it 'will load articles without hydrating' do
+      expect(channel).to receive(:get_request).and_return(
+        'data' => [{ 'id' => '123', 'type' => 'article', 'title' => 'Test Article' }]
+      )
+      article = channel.articles(hydrate: false).first
+      expect(article.id).to eq('123')
+    end
   end
 
 end

--- a/spec/apple/section_spec.rb
+++ b/spec/apple/section_spec.rb
@@ -61,6 +61,23 @@ describe AppleNews::Section do
       channel = section.channel
       expect(channel.config).to be(config)
     end
+
+    it 'will load and hydrate articles' do
+      allow_any_instance_of(AppleNews::Article).to receive(:fetch_data).and_return('data' => {})
+      expect(section).to receive(:get_request).and_return(
+        'data' => [{ 'id' => '123', 'type' => 'article', 'title' => 'Test Article' }]
+      )
+      article = section.articles.first
+      expect(article.id).to eq('123')
+    end
+
+    it 'will load articles without hydrating' do
+      expect(section).to receive(:get_request).and_return(
+        'data' => [{ 'id' => '123', 'type' => 'article', 'title' => 'Test Article' }]
+      )
+      article = section.articles(hydrate: false).first
+      expect(article.id).to eq('123')
+    end
   end
 
 end


### PR DESCRIPTION
### Purpose

This PR adds the ability to opt out of hydration when loading channel or section articles. It also fixes a few bugs related to setting article properties.

Closes #5

### Notable Changes

- Added a `hydrate` param to `Channel#articles` and `Section#articles`. When the param is set to `false`, the data hash will be passed to the article constructor - bypassing hydration.

- As part of the above, I also created a `get_request` wrapper around the `Request::Get.new(...).call` usage. This was partially to DRY things up, but mainly for ease of mocking in the tests.

- Fixed a bug in `load_properties` where camel cased properties coming in from the API were not being set.

- Added `Article#assign_data` to DRY up attribute assignment and ensure that both read-only and property system attributes are set correctly. As part of this I also added all the remaining attributes from the API docs.

### Tests

Yes! I added tests for everything, particularly for expectations re: assigning and serializing attributes. I _think_ everything is behaving as intended, but you should probably double check that my assumptions are correct.
