### PR TITLE
add isDevelopingStory to article

### DIFF
--- a/lib/apple-news/article.rb
+++ b/lib/apple-news/article.rb
@@ -10,7 +10,7 @@ module AppleNews
     include Properties
 
     optional_properties :is_sponsored, :is_preview, :accessory_text, :revision,
-                        :maturity_rating, :is_candidate_to_be_featured
+                        :maturity_rating, :is_candidate_to_be_featured, :is_developing_story
     optional_property :links, {}
 
     attr_reader :id, :type, :title, :share_url, :state, :warnings, :created_at, :modified_at

--- a/spec/apple/article_spec.rb
+++ b/spec/apple/article_spec.rb
@@ -18,6 +18,7 @@ describe AppleNews::Article do
       'isCandidateToBeFeatured' => true,
       'isSponsored'             => false,
       'isPreview'               => false,
+      'isDevelopingStory'       => false,
       'links' => {
         'channel' => 'https://news-api.apple.com/channels/c111',
         'sections' => [
@@ -122,6 +123,7 @@ describe AppleNews::Article do
         'isCandidateToBeFeatured' => false,
         'isSponsored'             => true,
         'isPreview'               => false,
+        'isDevelopingStory'       => false,
         'links' => {
           'sections' => [
             'https://news-api.apple.com/sections/s333'


### PR DESCRIPTION
This is a new field provided by apple news for live / developing stories.

I noticed that it had been a year since any updates had been made to the gem (could also be a year since apple changed things...) but i'd be happy to assist / take over maintenance since we are using this gem in production. 